### PR TITLE
PARQUET-113: Add specs for LIST and MAP annotations.

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -159,6 +159,10 @@ that is neither contained by a `LIST`- or `MAP`-annotated group nor annotated
 by `LIST` or `MAP` should be interpreted as a required list of required
 elements where the element type is the type of the field.
 
+Implementations should use either `LIST` and `MAP` annotations _or_ unannotated
+repeated fields, but not both. When using the annotations, no unannotated
+repeated types are allowed.
+
 ### Lists
 
 `LIST` is used to annotate types that should be interpreted as lists.
@@ -178,7 +182,8 @@ elements where the element type is the type of the field.
   `optional` or `required` and determines whether the list is nullable.
 * The middle level, named `list`, must be a repeated group with a single
   field named `element`.
-* The `element` field encodes the list's element type and repetition.
+* The `element` field encodes the list's element type and repetition. Element
+  repetition must be `required` or `optional`.
 
 The following examples demonstrate two of the possible lists of string values.
 
@@ -296,7 +301,7 @@ to values. `MAP` must annotate a 3-level structure:
 * The `key` field encodes the map's key type. This field must have
   repetition `required` and must always be present.
 * The `value` field encodes the map's value type and repetition. This field can
-  be `optional` or omitted.
+  be `required`, `optional`, or omitted.
 
 The following example demonstrates the type for a non-null map from strings to
 nullable integers:

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -167,16 +167,16 @@ elements where the element type is the type of the field.
 
 ```
 <list-repetition> group <name> (LIST) {
-  repeated group array {
+  repeated group list {
     <element-repetition> <element-type> element;
   }
 }
 ```
 
 * The outer-most level must be a group annotated with `LIST` that contains a
-  single field named `array`. The repetition of this level must be either
+  single field named `list`. The repetition of this level must be either
   `optional` or `required` and determines whether the list is nullable.
-* The middle level, named `array`, must be a repeated group with a single
+* The middle level, named `list`, must be a repeated group with a single
   field named `element`.
 * The `element` field encodes the list's element type and repetition.
 
@@ -185,14 +185,14 @@ The following examples demonstrate two of the possible lists of string values.
 ```
 // List<String> (list non-null, elements nullable)
 required group my_list (LIST) {
-  repeated group array {
+  repeated group list {
     optional binary element (UTF8);
   }
 }
 
 // List<String> (list nullable, elements non-null)
 optional group my_list (LIST) {
-  repeated group array {
+  repeated group list {
     required binary element (UTF8);
   }
 }
@@ -203,9 +203,9 @@ Element types can be nested structures. For example, a list of lists:
 ```
 // List<List<Integer>>
 optional group array_of_arrays (LIST) {
-  repeated group array {
+  repeated group list {
     required group element (LIST) {
-      repeated group array {
+      repeated group list {
         required int32 element;
       }
     }
@@ -237,17 +237,15 @@ should always be determined by the following rules based on the repeated field:
    elements are required.
 2. If the repeated field is a group with multiple fields, then its type is the
    element type and elements are required.
-3. If the repeated field is a group with one field, then the field's type is
-   the element type with the field's repetition.
+3. If the repeated field is a group with one field and is named either "array"
+   or uses the `LIST`-annotated group's name with "tuple" appended then the
+   repeated type is the element type and elements are required.
+4. Otherwise, the repeated field's type is the element type with the repeated
+   field's repetition.
 
 Examples that can be interpreted using these rules:
 
 ```
-// List<Integer> (non-null list, nullable elements)
-repeated group my_list (LIST) {
-  optional int32 element;
-}
-
 // List<Integer> (nullable list, non-null elements)
 optional group my_list (LIST) {
   repeated int32 element;
@@ -258,6 +256,20 @@ optional group my_list (LIST) {
   repeated group element {
     required binary str (UTF8);
     required int32 num;
+  };
+}
+
+// List<OneTuple<String>> (nullable list, non-null elements)
+optional group my_list (LIST) {
+  repeated group array {
+    required binary str (UTF8);
+  };
+}
+
+// List<OneTuple<String>> (nullable list, non-null elements)
+optional group my_list (LIST) {
+  repeated group my_list_tuple {
+    required binary str (UTF8);
   };
 }
 ```

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -229,17 +229,6 @@ optional group my_list (LIST) {
 }
 ```
 
-Some existing data uses `LIST` to annotate the repeated group named `array` in
-the above requirements, without the outer group. For backward-compatibility,
-this structure must be supported as a required list named for the repeated group.
-
-```
-// List<String> (non-null list)
-repeated group my_list (LIST) {
-  required binary element (UTF8);
-}
-```
-
 Some existing data did not include the inner element layer. For
 backward-compatibility, the type of elements in `LIST`-annotated structures
 should always be determined by the following rules based on the repeated field:
@@ -322,15 +311,3 @@ It is required that the repeated group of key-value pairs is named `key_value`
 and that its fields are named `key` and `value`. However, these names may not
 be used in existing data and should not be enforced as errors when reading.
 
-Some existing data uses `MAP` to annotate repeated key-value groups, the middle
-level named `key_value` in the above requirements. For backward-compatibility,
-this structure must be supported as a required map named for the repeated
-group.
-
-```
-// Map<String, Integer> (non-null map)
-repeated group my_map (MAP) {
-  required binary key (UTF8);
-  optional int32 value;
-}
-```

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -323,3 +323,28 @@ It is required that the repeated group of key-value pairs is named `key_value`
 and that its fields are named `key` and `value`. However, these names may not
 be used in existing data and should not be enforced as errors when reading.
 
+Some existing data incorrectly used `MAP_KEY_VALUE` in place of `MAP`. For
+backward-compatibility, a group annotated with `MAP_KEY_VALUE` that is not
+contained by a `MAP`-annotated group should be handled as a `MAP`-annotated
+group.
+
+Examples that can be interpreted using these rules:
+
+```
+// Map<String, Integer> (nullable map, non-null values)
+optional group my_map (MAP) {
+  repeated group map {
+    required binary str (UTF8);
+    required int32 num;
+  }
+}
+
+// Map<String, Integer> (nullable map, nullable values)
+optional group my_map (MAP_KEY_VALUE) {
+  repeated group map {
+    required binary key (UTF8);
+    optional int32 value;
+  }
+}
+```
+


### PR DESCRIPTION
Draft specs for using `MAP` and `LIST` annotations.

Please help verify that this can read all existing map and list data correctly!