### PR TITLE
PARQUET-184: Add release scripts.

### DIFF
--- a/dev/release-prepare.sh
+++ b/dev/release-prepare.sh
@@ -25,7 +25,7 @@ if [ -z "$version" ]; then
   exit
 fi
 
-tag=apache-parquet-format-$version
+tag=apache-parquet-format-$version-incubating
 
 mvn release:clean
 mvn release:prepare -Dtag=$tag -DreleaseVersion=$version

--- a/dev/release-prepare.sh
+++ b/dev/release-prepare.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version=$1
+
+if [ -z "$version" ]; then
+  echo "Usage: $0 <version>"
+  exit
+fi
+
+tag=apache-parquet-format-$version
+
+mvn release:clean
+mvn release:prepare -Dtag=$tag -DreleaseVersion=$version
+
+echo "Finish staging binary artifacts by running: mvn release:perform"

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version=$1
+rc=$2
+
+if [ -z "$version" ]; then
+  echo "Usage: $0 <version> <rc-num>"
+  exit
+fi
+
+if [ -z "$rc" ]; then
+  echo "Usage: $0 <version> <rc-num>"
+  exit
+fi
+
+if [ -d tmp/ ]; then
+  echo "Cannot run: tmp/ exists"
+  exit
+fi
+
+tag=apache-parquet-format-$version
+tagrc=${tag}-rc${rc}
+
+echo "Preparing source for $tag_rc"
+
+release_hash=`git rev-list $tag 2> /dev/null | head -n 1 `
+
+if [ -z "$release_hash" ]; then
+  echo "Cannot continue: unknown git tag: $tag"
+  exit
+fi
+
+echo "Using commit $release_hash"
+
+tarball=$tag-incubating.tar.gz
+
+# be conservative and use the release hash, even though git produces the same
+# archive (identical hashes) using the scm tag
+git archive $release_hash --prefix $tag/ -o $tarball
+
+# sign the archive
+gpg --armor --output ${tarball}.asc --detach-sig $tarball
+gpg --print-md MD5 $tarball > ${tarball}.md5
+shasum $tarball > ${tarball}.sha
+
+# check out the parquet RC folder
+svn co --depth=empty https://dist.apache.org/repos/dist/dev/incubator/parquet tmp
+
+# add the release candidate for the tag
+mkdir -p tmp/$tagrc
+cp ${tarball}* tmp/$tagrc
+svn add tmp/$tagrc
+svn ci -m "Apache Parquet Format (Incubating) $version RC${rc}" tmp/$tagrc
+
+# clean up
+rm -rf tmp
+
+echo "Success! The release candidate is available here:"
+echo "  https://dist.apache.org/repos/dist/dev/incubator/parquet/$tagrc"
+echo ""
+echo "Commit SHA1: $release_hash"
+

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -36,10 +36,10 @@ if [ -d tmp/ ]; then
   exit
 fi
 
-tag=apache-parquet-format-$version
+tag=apache-parquet-format-$version-incubating
 tagrc=${tag}-rc${rc}
 
-echo "Preparing source for $tag_rc"
+echo "Preparing source for $tagrc"
 
 release_hash=`git rev-list $tag 2> /dev/null | head -n 1 `
 
@@ -50,7 +50,7 @@ fi
 
 echo "Using commit $release_hash"
 
-tarball=$tag-incubating.tar.gz
+tarball=$tag.tar.gz
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag


### PR DESCRIPTION
These help with the release process, which is roughly:
* `sh dev/release-prepare.sh <version>`
* `mvn release:perform`
* `sh dev/source-release.sh <version> <rc-num>`
* Send a vote e-mail

The documentation is posted here: https://github.com/rdblue/incubator-parquet-site/blob/release-docs/site/source/how-to-release.html.md