### PR TITLE
PARQUET-188: Add ColumnChunk metadata order to the spec.

### DIFF
--- a/src/thrift/parquet.thrift
+++ b/src/thrift/parquet.thrift
@@ -509,6 +509,9 @@ struct ColumnChunk {
 }
 
 struct RowGroup {
+  /** Metadata for each column chunk in this row group.
+   * This list must have the same order as the SchemaElement list in FileMetaData.
+   **/
   1: required list<ColumnChunk> columns
 
   /** Total byte size of all the uncompressed column data in this row group **/


### PR DESCRIPTION
As discussed on PARQUET-188, this updates the file format spec to state that the column metadata order should match the schema column order.